### PR TITLE
Add Rayls Testnet Support to EAS Indexing Service

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -41,6 +41,17 @@ if (!CHAIN_ID) {
 
 export const EAS_CHAIN_CONFIGS: EASChainConfig[] = [
   {
+    chainId: 1632025,
+    chainName: "Rayls Testnet",
+    subdomain: "",
+    version: "1.4.0",
+    contractAddress: "0xC2679fBD37d54388Ce493F1DB75320D236e1815e",
+    schemaRegistryAddress: "0x240F841540c7Ba964b0d9Ca869AcDeaa62684C27",
+    etherscanURL: "https://rayls-test-chain.explorer.caldera.xyz",
+    contractStartBlock: 22417,
+    rpcProvider: "https://rayls-test-chain.rpc.caldera.xyz",
+  },
+  {
     chainId: 11155111,
     chainName: "sepolia",
     subdomain: "",


### PR DESCRIPTION
### Summary
This pull request adds support for the Rayls Testnet blockchain network to the EAS (Ethereum Attestation Service) indexing service, enabling attestation monitoring and indexing on this new testnet environment.

### Changes Made
Added Rayls Testnet configuration to EAS_CHAIN_CONFIGS with the following specifications:

```
Chain ID: 1632025
Chain Name: Rayls Testnet
EAS Contract: 0xC2679fBD37d54388Ce493F1DB75320D236e1815e
Schema Registry: 0x240F841540c7Ba964b0d9Ca869AcDeaa62684C27
Explorer: https://rayls-test-chain.explorer.caldera.xyz
RPC Provider: https://rayls-test-chain.rpc.caldera.xyz
Start Block: 22417
Version: 1.4.0
```